### PR TITLE
fix: re-enable remote config download

### DIFF
--- a/src/generate-data.lua
+++ b/src/generate-data.lua
@@ -191,7 +191,7 @@ end
 local function load_config(name, config)
 	local docs = config.docs or {}
 	local lang = languages[name] or name
-	local data = {}--load_external_data(name, docs)
+	local data = load_external_data(name, docs)
 
 	local settings = {}
 	if data then


### PR DESCRIPTION
This was accidentally left off for development purposes