### PR TITLE
fix: broken syntax on configuration pages

### DIFF
--- a/src/generate-data.lua
+++ b/src/generate-data.lua
@@ -243,10 +243,9 @@ local function load_config(name, config)
                 table.insert(root_dir, fileContent[i])
             end
 
-            v = table.concat(root_dir, '\n')
-            v = string.gsub(v, '.*function', 'function')
+            v = table.concat(root_dir, '\n'):gsub('.*function', 'function')
         else
-            v = vim.inspect(v)
+            v = vim.inspect(v):gsub('<function %d>', 'function() --[[ see lua configuration file ]] end')
         end
 
         table.insert(default_config, string.format('%s = %s,', k, v))


### PR DESCRIPTION
Because of the nature of `vim.inspect` and the generation of default
values in configuration documentation there are cases where the
following would be added:

```
something = {
  ["key"] = <function 1>
}
```

This fix prevents this by replacing these function tags with actual Lua
code. In the future this should probably read the functions from source
as is done in other cases.